### PR TITLE
Dev --> main: removed unnecessary info (devid and anonid) from account screen, removed unused email and spotify sections for later implementation 

### DIFF
--- a/src/features/account/AccountView.jsx
+++ b/src/features/account/AccountView.jsx
@@ -44,10 +44,6 @@ export default function AccountView({
   regeneratingRecoveryCode = false,
   regenerationError = null,
   onOpenRestoreDialog,
-  onOpenSpotifyLink,
-  spotifyLinked = false,
-  spotifyAccountLabel = '',
-  emailLinkingEnabled = false,
   onRequestRecoveryModal,
   showBackupPrompt = false,
 }) {
@@ -60,10 +56,6 @@ export default function AccountView({
     () => formatTimestamp(recoveryAcknowledgedAt),
     [recoveryAcknowledgedAt]
   );
-
-  const spotifyStatus = spotifyLinked
-    ? spotifyAccountLabel || 'Linked'
-    : 'Not linked';
 
   useEffect(() => {
     if (!masked) {

--- a/src/features/account/__tests__/AccountView.test.jsx
+++ b/src/features/account/__tests__/AccountView.test.jsx
@@ -17,11 +17,7 @@ const baseProps = {
   onConfirmRegenerate: vi.fn(),
   onCopyRecoveryCode: vi.fn(),
   onOpenRestoreDialog: vi.fn(),
-  onOpenSpotifyLink: vi.fn(),
   onRequestRecoveryModal: vi.fn(),
-  spotifyLinked: false,
-  spotifyAccountLabel: '',
-  emailLinkingEnabled: true,
   showBackupPrompt: false,
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Spotify linking and email linking options from account settings
  * Simplified account view by removing device and anonymous ID display
  * Updated account recovery description text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->