### PR TITLE
fix: stop tag chip remove clicks from triggering filters

### DIFF
--- a/src/features/playlist/__tests__/TrackCard.test.jsx
+++ b/src/features/playlist/__tests__/TrackCard.test.jsx
@@ -51,7 +51,7 @@ describe('TrackCard', () => {
     window.cancelAnimationFrame = originalCancelRaf
   })
 
-  it('invokes onRemoveTag and onFilterTag when tag chip clicked', async () => {
+  it('removes tag without triggering filter when chip clicked', async () => {
     const onRemoveTag = vi.fn()
     const onFilterTag = vi.fn()
     const { user } = renderTrackCard({ onRemoveTag, onFilterTag })
@@ -60,7 +60,7 @@ describe('TrackCard', () => {
     await user.click(chip)
 
     expect(onRemoveTag).toHaveBeenCalledWith('track-1', 'rock')
-    expect(onFilterTag).toHaveBeenCalledWith('rock')
+    expect(onFilterTag).not.toHaveBeenCalled()
   })
 
   it('calls onCancelNote when cancel button pressed during editing', async () => {

--- a/src/features/tags/TagChip.jsx
+++ b/src/features/tags/TagChip.jsx
@@ -36,19 +36,20 @@ function TagChipInner(props, ref) {
   } = safeProps
 
   const handleClick = (event) => {
-    if (onClick) {
-      onClick(event);
+    if (typeof onClick === 'function') {
+      onClick(event)
     }
-    if (event.defaultPrevented) return;
-    event.preventDefault();
-    event.stopPropagation();
-    if (onFilter) {
-      onFilter(tag);
+    if (event.defaultPrevented) return
+    event.preventDefault()
+    event.stopPropagation()
+    if (typeof onRemove === 'function') {
+      onRemove(tag)
+      return
     }
-    if (onRemove) {
-      onRemove(tag);
+    if (typeof onFilter === 'function') {
+      onFilter(tag)
     }
-  };
+  }
 
   return (
     <button

--- a/src/features/tags/__tests__/TagChip.test.jsx
+++ b/src/features/tags/__tests__/TagChip.test.jsx
@@ -9,13 +9,13 @@ describe('TagChip', () => {
     expect(button).toHaveAttribute('aria-pressed', 'true')
   })
 
-  it('invokes filter and remove callbacks when clicked', () => {
+  it('prefers remove callback over filter when both provided', () => {
     const onFilter = vi.fn()
     const onRemove = vi.fn()
     render(<TagChip tag="drill" onFilter={onFilter} onRemove={onRemove} />)
     fireEvent.click(screen.getByRole('button', { name: /remove tag drill/i }))
-    expect(onFilter).toHaveBeenCalledWith('drill')
     expect(onRemove).toHaveBeenCalledWith('drill')
+    expect(onFilter).not.toHaveBeenCalled()
   })
 
   it('respects onClick handlers that prevent default behavior', () => {
@@ -36,5 +36,12 @@ describe('TagChip', () => {
     render(<TagChip tag="solo" onRemove={onRemove} />)
     fireEvent.click(screen.getByRole('button', { name: /remove tag solo/i }))
     expect(onRemove).toHaveBeenCalledWith('solo')
+  })
+
+  it('handles filter-only chips', () => {
+    const onFilter = vi.fn()
+    render(<TagChip tag="focus" onFilter={onFilter} />)
+    fireEvent.click(screen.getByRole('button', { name: /remove tag focus/i }))
+    expect(onFilter).toHaveBeenCalledWith('focus')
   })
 })


### PR DESCRIPTION
Tag chips now prioritize removal over filtering, so clicking a tag no longer activates the filter UI.

Added unit tests for both TagChip and TrackCard to cover remove-first behavior and filter-only chips.

gpt-5-codex-low

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tag removal now operates independently from filtering, preventing unintended filter triggers when removing tags from your content.

* **Tests**
  * Updated test coverage to ensure remove and filter operations work with correct precedence for tag interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->